### PR TITLE
Switch SAMMI integration to WebSockets server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ dashmap = "5.3"
 once_cell = { version = "1.13", features = ["parking_lot"] }
 region = "3.0.0"
 serde_json = { version = "1.0.120", optional = true }
-tokio = { version = "1.39.1", features = ["rt", "sync"], optional = true }
+tokio = { version = "1.39.1", features = ["rt", "sync", "macros"], optional = true }
 reqwest = { version = "0.12.5", optional = true }
 steamworks-sys = "0.11.0"
+tokio-tungstenite = "0.24.0"
+futures-util = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [features]
-sammi = ["tokio", "reqwest", "serde_json"]
+sammi = ["tokio", "serde_json", "tokio-tungstenite"]
 default = ["sammi"]
 
 [dependencies]
@@ -39,8 +39,11 @@ dashmap = "5.3"
 once_cell = { version = "1.13", features = ["parking_lot"] }
 region = "3.0.0"
 serde_json = { version = "1.0.120", optional = true }
-tokio = { version = "1.39.1", features = ["rt", "sync", "macros"], optional = true }
-reqwest = { version = "0.12.5", optional = true }
+tokio = { version = "1.39.1", features = [
+    "rt",
+    "sync",
+    "macros",
+], optional = true }
+tokio-tungstenite = { version = "0.24.0", optional = true }
 steamworks-sys = "0.11.0"
-tokio-tungstenite = "0.24.0"
 futures-util = "0.3.31"

--- a/src/game/hooks.rs
+++ b/src/game/hooks.rs
@@ -2,7 +2,10 @@ use super::{get_script_file, internal, names, offset, ScriptFile, ScriptType};
 use crate::game::get_script_filename;
 use crate::global::GlobalMut;
 use crate::helpers::get_aob_offset;
-use crate::{global, make_fn, sammi};
+use crate::{global, make_fn};
+
+#[cfg(feature = "sammi")]
+use crate::sammi;
 
 use std::ffi::CStr;
 use std::ptr;
@@ -121,7 +124,8 @@ unsafe fn gamestate_advance_hook(game_state: *mut u8, other: *mut u8) {
         other as usize,
     );
 
-    if cfg!(feature = "sammi") {
+    #[cfg(feature = "sammi")]
+    {
         log::trace!("gathering state for sammi...");
         crate::sammi::game_loop_hook_sammi();
     }

--- a/src/global.rs
+++ b/src/global.rs
@@ -8,7 +8,9 @@ use std::{
     path::PathBuf,
 };
 
-use crate::{helpers, sammi};
+use crate::helpers;
+#[cfg(feature = "sammi")]
+use crate::sammi;
 
 pub type GlobalMut<T> = Lazy<Mutex<T>>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub unsafe extern "stdcall" fn DllMain(
                     .build()
                     .unwrap();
                 runtime.block_on(async move {
-                    sammi::message_handler(rx).await;
+                    sammi::start_websocket_server(rx).await;
                 });
             });
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,8 @@ pub unsafe extern "stdcall" fn DllMain(
 
     if attach_reason == DLL_PROCESS_ATTACH {
         // if sammi is used we set up the message passing state
-        if cfg!(feature = "sammi") {
+        #[cfg(feature = "sammi")]
+        {
             let (tx, rx) = tokio::sync::mpsc::channel(8);
             global::MESSAGE_SENDER.get_or_init(move || tx);
             thread::spawn(|| unsafe { initialize() });
@@ -56,7 +57,9 @@ pub unsafe extern "stdcall" fn DllMain(
                     sammi::start_websocket_server(rx).await;
                 });
             });
-        } else {
+        }
+        #[cfg(not(feature = "sammi"))]
+        {
             thread::spawn(|| unsafe { initialize() });
         }
     };

--- a/src/ui/gui.rs
+++ b/src/ui/gui.rs
@@ -1,6 +1,7 @@
 use crate::game::offset::GameState;
 use crate::game::offset::GAMESTATE_PTR;
 use crate::global;
+#[cfg(feature = "sammi")]
 use crate::sammi;
 
 use std::borrow::Cow;


### PR DESCRIPTION
This greatly speeds up the SAMMI integration by allowing clients to connect to a WebSockets server hosted by the game. It also allows any number of clients to connect and receive the same data, which will make many kinds of non-SAMMI web applications integrating with the mod possible while SAMMI is also connected via an extension